### PR TITLE
Add 'enoughemail.com' label to the filtered emails

### DIFF
--- a/app/controllers/organization_credentials_tests_controller.rb
+++ b/app/controllers/organization_credentials_tests_controller.rb
@@ -15,6 +15,12 @@ class OrganizationCredentialsTestsController < AuthenticatedController
       error_messages[:gmail_basic_settings_access] = check_for_errors do
         service.list_filters(user_email: users.last.primary_email)
       end
+
+      if current_user.organization.google_auth_scope_set == "with_labels"
+        error_messages[:gmail_labels] = check_for_errors do
+          service.list_labels(user_email: users.last.primary_email)
+        end
+      end
     end
 
     if error_messages.values.flatten.empty?
@@ -51,7 +57,7 @@ class OrganizationCredentialsTestsController < AuthenticatedController
         error_messages << "Google credentials unauthorized. Is 'Admin email' setting on the organization correct?"
       when "Requested client not authorized."
         error_messages << "Google credentials unauthorized. Are scopes in Google Workspace Admin panel for domain-wide delegation set up correctly?"
-        error_messages << "Scopes required: '#{Google::Service::SCOPES.join(",")}'"
+        error_messages << "Scopes required: '#{Google::Service::SCOPES.fetch("with_labels").join(",")}'"
       else
         error_messages << "Google credentials unauthorized. Have you set up domain-wide delegation? Have credentials expired or were removed? Google error description: #{response_body["error_description"].strip}"
       end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -66,6 +66,12 @@ class OrganizationsController < AuthenticatedController
 
   # Only allow a list of trusted parameters through.
   def organization_params
-    params.require(:organization).permit(:domain, :billing_email, :google_domain_wide_delegation_credentials, :admin_email)
+    params.require(:organization).permit(
+      :domain,
+      :billing_email,
+      :google_domain_wide_delegation_credentials,
+      :admin_email,
+      :google_auth_scope_set
+    )
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,6 +10,8 @@ class Organization < ApplicationRecord
   validates :google_domain_wide_delegation_credentials, presence: true
   validate :non_common_domain
 
+  enum google_auth_scope_set: Google::Service::SCOPES.keys.map { |k| [k, k] }.to_h.freeze
+
   def self.for_user_email(email_address)
     domain = email_address.split("@").last.downcase
     find_by(domain: domain)
@@ -18,7 +20,8 @@ class Organization < ApplicationRecord
   def google_service
     Google::Service.new(
       credentials_json: google_domain_wide_delegation_credentials,
-      org_admin_email: admin_email
+      org_admin_email: admin_email,
+      auth_scope_set: google_auth_scope_set
     )
   end
 

--- a/app/views/organizations/_form.html.haml
+++ b/app/views/organizations/_form.html.haml
@@ -30,17 +30,17 @@
 
         %p It requires a very minimal set of permissions, ensuring that Enough Email does not have access to any of the email contents inside your organization.
 
-        %p.font-bold
-          Follow these instructions to
-          = link_to "set up a Service Account", "https://developers.google.com/workspace/guides/create-credentials#service-account", taget: :blank, class: "underline text-indigo-700"
+        .font-bold.text-lg.bg-indigo-200.border-indigo-900.p-4.text-gray-900
+          = inline_svg_tag "fa-icons/solid/arrow-right.svg", class: "h-6 w-6 fill-green-800 mr-1 inline-block"
+          = link_to "Follow these instructions to set up a Service Account", "https://developers.google.com/workspace/guides/create-credentials#service-account", taget: :blank, class: "underline text-indigo-700"
           , please make sure to
           %b enable domain-wide delegation.
 
-        %h3.text-lg Mandatory permissions
+        %h3.text-lg Permissions
 
         %p
           The following permissions are required. You can read more about scopes in
-          = link_to "Google's documentation.", "https://developers.google.com/gmail/api/auth/scopes", target: :_blank
+          = link_to "Google's documentation.", "https://developers.google.com/gmail/api/auth/scopes", target: :_blank, class: "underline"
         .overflow-auto
           %table.min-w-full.max-w-full.border
             %tr.bg-white.border-b
@@ -54,23 +54,10 @@
               %td.text-gray-900.px-6.py-4.text-left
                 %pre.py-1.overflow-x-scroll.font-monospace.border.rounded.bg-gray-100.px-2.block.py-1 https://www.googleapis.com/auth/gmail.settings.basic
               %td.text-gray-900.px-6.py-4.text-left Allows Enough Email to add new email Filters for users in your organization
-
-        %h3.text-lg Optional permissions
-
-        %p Add the following scopes if you are OK with enoughemail.com seeing your email subjects and headers (email body will remain invisible). Optional permissions will allow enoughemail.com to tag block emails with a Gmail label and calculate stats of how many emails are being filtered. This feature will be implemented in future.
-        .overflow-auto
-          %table.min-w-full.max-w-full.border
-            %tr.bg-white.border-b
-              %th.font-medium.text-gray-900.px-6.py-4.text-left Permission scope
-              %th.font-medium.text-gray-900.px-6.py-4.text-left Explanation
             %tr
               %td.text-gray-900.px-6.py-4.text-left
                 %pre.py-1.overflow-x-scroll.font-monospace.border.rounded.bg-gray-100.px-2.block.py-1 https://www.googleapis.com/auth/gmail.labels
               %td.text-gray-900.px-6.py-4.text-left Allows Enough Email to create labels so that filtered emails can be tagged.
-            %tr
-              %td.text-gray-900.px-6.py-4.text-left
-                %pre.py-1.overflow-x-scroll.font-monospace.border.rounded.bg-gray-100.px-2.block.py-1 https://www.googleapis.com/auth/gmail.metadata
-              %td.text-gray-900.px-6.py-4.text-left Allows Enough Email to look at the email headers and labels, so that it can generate stats of filtered emails.
 
         %p Once set up, paste the credentials JSON contents into the field above. Credentials look like this:
 

--- a/db/migrate/20221202110552_add_google_auth_scopes_set_to_organization.rb
+++ b/db/migrate/20221202110552_add_google_auth_scopes_set_to_organization.rb
@@ -1,0 +1,7 @@
+class AddGoogleAuthScopesSetToOrganization < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :google_auth_scope_set, :text, default: "with_labels"
+
+    Organization.update_all(google_auth_scope_set: "minimal")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_26_181333) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_02_110552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -122,6 +122,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_26_181333) do
     t.datetime "updated_at", null: false
     t.string "admin_email"
     t.text "slack_webhook_url"
+    t.text "google_auth_scope_set", default: "with_labels"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
In a backwards compatible way, add the new required scope permission. Then change the filter rule creation logic to also create if needed and add 'enoughemail.com' label.

What's cool about this is that if you fetch an individual label, it will have the count of emails tagged with it, making it possible to gauge the stats of how many emails where filtered over time for each user